### PR TITLE
Workaround for 'broken' MailScanner clamav-wrapper

### DIFF
--- a/mailscanner/clamav_status.php
+++ b/mailscanner/clamav_status.php
@@ -45,7 +45,7 @@ if ($_SESSION['user_type'] !== 'A') {
     echo '<td align="center">';
 
     // Output the information from the conf file
-    passthru(get_virus_conf('clamav') . ' -V | awk -f ' . __DIR__ . '/clamav.awk');
+    passthru(get_virus_conf('clamav') . ' . -V | awk -f ' . __DIR__ . '/clamav.awk');
 
     echo '</td>';
     echo '</tr>';


### PR DESCRIPTION
Return ClamAV version details when MailScanner's clamav-wrapper swallows the -V parameter because it is expecting a path to scan.  Fixes Issue #970