### PR TITLE
Get clamav version info without using MailScanner's clamav-wrapper

### DIFF
--- a/mailscanner/clamav_status.php
+++ b/mailscanner/clamav_status.php
@@ -43,10 +43,11 @@ if ($_SESSION['user_type'] !== 'A') {
     echo '<table class="boxtable" width="100%">';
     echo '<tr>';
     echo '<td align="center">';
-
-    // Output the information from the conf file
-    passthru(get_virus_conf('clamav') . ' . -V | awk -f ' . __DIR__ . '/clamav.awk');
-
+    // Find path to clamscan binary and run 'clamscan -V' to get version info
+    exec("which clamscan", $clamscan);
+    if (isset($clamscan[0])) {
+        passthru("$clamscan[0] -V | awk -f " . __DIR__ . '/clamav.awk');
+    }
     echo '</td>';
     echo '</tr>';
     echo '</table>';


### PR DESCRIPTION
Update clamav_status.php to remove dependencies on MailScanner's clamav-wrapper.

Avoids unneccessary permissions issues as in issue #970