### PR TITLE
Get clamav version info without using MailScanner's clamav-wrapper

### DIFF
--- a/mailscanner/sf_version.php
+++ b/mailscanner/sf_version.php
@@ -132,7 +132,10 @@ if ($_SESSION['user_type'] !== 'A') {
     // Add test for others virus scanners.
     if (preg_match('/clam/i', $virusScanner)) {
         echo 'ClamAV ' . __('version11') . ' ';
-        passthru(get_virus_conf('clamav') . " -V | cut -d/ -f1 | cut -d' ' -f2");
+        exec("which clamscan", $clamscan);
+        if (isset($clamscan[0])) {
+            passthru("$clamscan[0] -V | cut -d/ -f1 | cut -d' ' -f2");
+        }
         echo '<br>' . "\n";
     }
 


### PR DESCRIPTION
Simplify sf_version.php to get clamav version info by directly calling 'clamscan -V' instead of using MailScanner's clamav-wrapper.

This avoids problematic permissions issues as in Issue #970